### PR TITLE
Fix: Handle FileNotFoundError during OS-dependent library cleanup phase

### DIFF
--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -389,7 +389,10 @@ def _remove_package(installation_path: str, package_name: str) -> bool:
                 raise ValueError(
                     f"Absolute paths are not allowed in RECORD files: {path}"
                 )
-            os.remove(os.path.join(installation_path, path))
+            try:
+                os.remove(os.path.join(installation_path, path))
+            except FileNotFoundError:
+                pass  # File already deleted or not present (e.g. bin scripts outside lib)
             top_level_dirs.add(path.split(separator)[0])
 
         for directory in top_level_dirs:


### PR DESCRIPTION
Wraps os.remove() in _remove_package() with try/except FileNotFoundError so that RECORD paths that no longer exist (e.g. ../../bin/f2py from numpy) do not crash the ucc-gen build.

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Please provide a summary of the changes.

### User experience

Please describe the user experience before and after this change. Screenshots are welcome for additional context.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
